### PR TITLE
Update/sampler sharing

### DIFF
--- a/include/lazarus_common.h
+++ b/include/lazarus_common.h
@@ -28,6 +28,10 @@
 #define RESET_TEXT "\x1b[37m"
 #define RED_TEXT  "\x1b[31m"
 
+#define LAZARUS_MAX_LIGHTS (64)
+#define LAZARUS_MAX_MOTIONPOINTS (64)
+#define LAZARUS_MAX_SELECTABLE_ENTITIES (255)
+
 extern void LOG_DEBUG(const char *DEBUG_MESSAGE);
 extern void LOG_ERROR(const char *ERR_MESSAGE, const char *ERR_FILENAME, uint32_t ERR_LINE);
 

--- a/include/lazarus_mesh.h
+++ b/include/lazarus_mesh.h
@@ -213,6 +213,7 @@ class ModelManager
 
         lazarus_result setMaterials(AssetLoader::AssetData &assetData);
         lazarus_result setSelectable(bool selectable);
+        lazarus_result syncShader();
         lazarus_result uploadVertexData();
         lazarus_result uploadTextures();
         lazarus_result updateUniformLocations();

--- a/include/lazarus_window_manager.h
+++ b/include/lazarus_window_manager.h
@@ -109,6 +109,7 @@ class EventManager
          * while simultaniously deduplicating key events from the queue. 
          */
         std::set<int32_t> heldKeys;
+        std::vector<Event> events;
 
         int32_t latestKeyState;
 		int32_t latestScanState;

--- a/include/lazarus_window_manager.h
+++ b/include/lazarus_window_manager.h
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <set>
 
 #include "lazarus_file_loader.h"
 
@@ -58,7 +59,9 @@ class EventManager
     public:
         enum EventType
         {
-            KEY_PRESS,
+            KEY_DOWN,
+            KEY_HOLD,
+            KEY_UP,
             CLICK,
             MOUSE_MOVE,
             SCROLL
@@ -88,14 +91,24 @@ class EventManager
         void getLatestScroll(int32_t &out);
         
         std::vector<Event> eventQueue;
-            
+
         virtual ~EventManager();
 		
     protected:
+        /**
+         * used by glfw callback handlers to handle pushing incoming user window interactions into the event queue.
+         */
         void dispatchEvent(EventType variant, int32_t aValue, int32_t bValue);
         
     private:
         Event event;
+        
+        /**
+         * NOTE:
+         * Used for tracking keypresses between frames and promoting them to "KEY_HOLD" 
+         * while simultaniously deduplicating key events from the queue. 
+         */
+        std::set<int32_t> heldKeys;
 
         int32_t latestKeyState;
 		int32_t latestScanState;
@@ -138,7 +151,13 @@ class WindowManager : public EventManager, public Time
         virtual ~WindowManager();
         
 	private:
+        /**
+         * Starts up the gl extension wrangler
+         */
         void initialiseGLEW();
+        /**
+         * Moves the window to the center of the monitor.
+         */
         lazarus_result centerWindow();
         lazarus_result checkErrors(const char *file, int line);
 

--- a/readme.md
+++ b/readme.md
@@ -1533,7 +1533,9 @@ Free cubemaps: https://www.humus.name/index.php?page=Textures
 4. Texture images used in any scene should all have the same pixel width and height. If not, the scene *should* still render but you can expect to find holes in your textures. Use `GlobalsManager::enforceImageSanity` to ensure images are resized on load.
 5. The xy coordinate system of the orthographic camera created by `Camera::createOrthoCam` has `0.0` mapped to the top left corner of the window, while the perspective camera `Camera::createPerspectiveCam` uses the bottom left.
 6. There is no kerning or centering of TrueType fonts loaded by the `TextManager` class. If you need to render perfectly aligned text it may be better to render it directly to a quad as a texture (See: `Mesh::createQuad`). It could then be rendered along with the rest of the text by loading in an orthographic camera (See: `Camera::createOrthoCam`).
-7. The maximum number of lights permitted in any one scene while using the `LAZARUS_DEFAULT_VERT_SHADER` and/or `LAZARUS_DEFAULT_FRAG_SHADER` is limitted to a maximum size of 150.
-8. The maximum number of entities in any one scene who can be picked or looked up using a pixel with `CameraManager::getPixelOccupant` is limmited to a maximum size of 255.
-9. For linux systems using wayland graphical sessions, running in windowed mode will throw an error due to window repositioning (the window is centered so it doesn't just appear in a random place). Run the application in fullscreen with `GlobalsManager::setLaunchInFullscreen(true)`.
-10. All images must be formatted with RGBA 8-bit alignment
+7. The maximum number of lights permitted in any one scene while using the `LAZARUS_DEFAULT_VERT_SHADER` and/or `LAZARUS_DEFAULT_FRAG_SHADER` is limitted to a maximum size of 64.
+8. The maximum number of joints allowed for any one animated armature is currently limitted to a maximum size of 64.
+9. The maximum number of entities in any one scene who can be picked or looked up using a pixel with `CameraManager::getPixelOccupant` is limmited to a maximum size of 255.
+10. For linux systems using wayland graphical sessions, running in windowed mode will throw an error due to window repositioning (the window is centered so it doesn't just appear in a random place). Run the application in fullscreen with `GlobalsManager::setLaunchInFullscreen(true)`.
+11. All images must be formatted with RGBA 8-bit alignment
+12. Ensure that every vertex in an animated mesh that has been exported to glb format is assigned a weight. If some are missed, common modeling programs will add an extra bone to your rig at export-time to compensate for floating geometry -- this has a negative impact on the parser and will likely not load.

--- a/readme.md
+++ b/readme.md
@@ -403,7 +403,7 @@ Now lets create our geometry:
     quadSettings.height = 500;
 
     //  Generate asset
-    Lazarus::ModelManager::Quad quad = {};
+    Lazarus::ModelManager::Model quad = {};
     modelManager.createQuad(quad, quadSettings); //  upon success, quad is given a value
 ```
 
@@ -833,7 +833,9 @@ Params:
 ### Members:
 > **eventQueue:** *All meaningful changes that occured in event state since the last call to `monitorEvents()`. (type: `std::vector<WindowManager::EventManager::Event>`)* \
 > **EventType:** *Different event varieties. (type: `enum`)* 
->	- **KEY_PRESS:** *A keyboard button, pressed or released.* 
+>	- **KEY_DOWN:** *A keyboard button has been pressed.* 
+>	- **KEY_UP:** *A Held or pressed keyboard button has been released.* 
+>	- **KEY_HOLD** *A keyboard button is being held down.* 
 >	- **CLICK:** *A mouse button, pressed or released.* 
 >	- **MOUSE_MOVE:** *The cursor position on either the x or y axis (or both).*  
 >   - **SCROLL:** *The scroll / mouse wheel, up, down or neutral.*

--- a/readme.md
+++ b/readme.md
@@ -568,7 +568,6 @@ Anything not used from here will be optimised-out when compiled.
     vec3 _lazarusComputeLambertianReflection(vec3 color);   //  Calculate the fragment's diffuse lighting
     float _lazarusComputeFogFactor();                       //  Calculate fog attenuation
 ```
-**It should be noted that `_lazarusComputeColor()` will only return a value for a textured mesh when it is called from the program which the `ModelManager` was instantiated with.**
 
 ------------------------------------------------------------------
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Lazarus Engine
-#### *Version: 0.15.2*
+#### *Version: 0.15.3*
 ## Table of contents:
 
 - [Getting Started](#getting-started)

--- a/src/lazarus_common.cpp
+++ b/src/lazarus_common.cpp
@@ -42,7 +42,7 @@ uint32_t                 LAZARUS_PRIMARY_DISPLAY_WIDTH          = 0;
 uint32_t                 LAZARUS_PRIMARY_DISPLAY_HEIGHT         = 0;
 uint32_t                 LAZARUS_LIGHT_COUNT                    = 0;
 std::vector<uint32_t>    LAZARUS_SELECTABLE_ENTITIES            = {};
-const uint32_t           LAZARUS_MAX_LIGHTS                     = 150;
+const uint32_t           LAZARUS_MAX_LIGHTS                     = 64;
 const uint32_t           LAZARUS_MAX_SELECTABLE_ENTITIES        = 254;
 
 uint32_t                 LAZARUS_MAX_IMAGE_WIDTH                = 0;

--- a/src/lazarus_common.cpp
+++ b/src/lazarus_common.cpp
@@ -42,8 +42,6 @@ uint32_t                 LAZARUS_PRIMARY_DISPLAY_WIDTH          = 0;
 uint32_t                 LAZARUS_PRIMARY_DISPLAY_HEIGHT         = 0;
 uint32_t                 LAZARUS_LIGHT_COUNT                    = 0;
 std::vector<uint32_t>    LAZARUS_SELECTABLE_ENTITIES            = {};
-const uint32_t           LAZARUS_MAX_LIGHTS                     = 64;
-const uint32_t           LAZARUS_MAX_SELECTABLE_ENTITIES        = 254;
 
 uint32_t                 LAZARUS_MAX_IMAGE_WIDTH                = 0;
 uint32_t                 LAZARUS_MAX_IMAGE_HEIGHT               = 0;

--- a/src/lazarus_light.cpp
+++ b/src/lazarus_light.cpp
@@ -79,7 +79,7 @@ lazarus_result LightManager::createLightSource(LightManager::Light &out, LightMa
     try
     {
         lightStore.insert(std::pair<uint32_t, LightManager::LightData>(lightOut.id, lightData));
-        if(GlobalsManager::getNumberOfActiveLights() < UINT8_MAX)
+        if(GlobalsManager::getNumberOfActiveLights() < LAZARUS_MAX_LIGHTS)
         {
             GlobalsManager::setNumberOfActiveLights(this->lightCount);
         }

--- a/src/lazarus_mesh.cpp
+++ b/src/lazarus_mesh.cpp
@@ -52,6 +52,8 @@ ModelManager::ModelManager(Shader &shader, TextureLoader::StorageType textureTyp
 
 lazarus_result ModelManager::create3DAsset(ModelManager::Model &out, ModelManager::AssetConfig options)
 {
+    this->syncShader();
+
     this->modelOut = {};
     this->modelData = {};
     
@@ -304,17 +306,12 @@ lazarus_result ModelManager::create3DAsset(ModelManager::Model &out, ModelManage
 
 };
 
+/**
+ * Determines if any of the materials used by the meshes that compose `this->modelOut` contain 
+ * textures and engages the allocator.
+ */
 lazarus_result ModelManager::uploadTextures()
 {
-    /*
-        Reload the entire texture stack / array if the mesh isn't
-        being used for anything special like glyphs or skyboxes, which
-        use different loaders. 
-        
-        I.e. reallocate the existing memory size + the new amount and 
-        upload all of the textures again if the current mesh uses 
-        image textures.
-    */
     LOG_DEBUG("Uploading asset textures to GPU");
 
     bool containsTextures = false;
@@ -343,8 +340,14 @@ lazarus_result ModelManager::uploadTextures()
     return status;
 };
 
+/**
+ * Finds and sets the values of shader uniforms which are required for `this` to function correctly.
+ * 
+ * Most likely the active program in the Lazarus::Shader used to instantiate `this` has changed.
+ */
 lazarus_result ModelManager::updateUniformLocations()
 {
+    
     LOG_DEBUG("Setting updated model uniform locations");
     this->clearErrors();
 
@@ -373,6 +376,8 @@ lazarus_result ModelManager::updateUniformLocations()
 
 lazarus_result ModelManager::createQuad(ModelManager::Model &out, ModelManager::QuadConfig options)
 {
+    this->syncShader();
+
     LOG_DEBUG("Generating quad");
     
     if(options.width < 0.0f || options.height < 0.0f)
@@ -539,6 +544,8 @@ lazarus_result ModelManager::createQuad(ModelManager::Model &out, ModelManager::
 
 lazarus_result ModelManager::createCube(ModelManager::Model &out, ModelManager::CubeConfig options)
 {
+    this->syncShader();
+    
     LOG_DEBUG("Generating cube");
     float vertexPosition = options.scale / 2.0f; 
     
@@ -914,6 +921,15 @@ lazarus_result ModelManager::uploadVertexData()
 	
 };
 
+/*
+    Reallocates the current texture stack's memory size + 
+    the new amount and reUploads all of the textures again in-order
+    if the current mesh uses image textures.
+
+    I.e. Reloads the entire texture stack / array if `this->modelOut` isn't
+    being used for anything special like glyphs or skyboxes, which
+    use different loaders. 
+*/
 lazarus_result ModelManager::reallocateTextures()
 {
     LOG_DEBUG("Allocating additional texture storage");
@@ -1066,15 +1082,33 @@ lazarus_result ModelManager::setSelectable(bool selectable)
     }
 };
 
-lazarus_result ModelManager::loadModel(ModelManager::Model &meshIn)
-{   
+/**
+ * Determine whether the active shader program used by `this->shader` has changed and updates
+ * the reference if so.
+ */
+lazarus_result ModelManager::syncShader()
+{
+    lazarus_result status = lazarus_result::LAZARUS_OK;
     uint32_t program = 0;
+    /**
+     * TODO:
+     * During creation, uploadTextures needs to be called for each known program - not just the active one.
+     * The implications of the current behaviour mean that _lazarusComputeColor() cannot be called from any shader 
+     * other than that which was active during creation for models whose meshes use textures.
+     */
     shader->getActiveShader(program);
     if(this->activeShaderID != program)
     {
         this->activeShaderID = program;
-        this->updateUniformLocations();
+        status = this->updateUniformLocations();
     };
+    
+    return status;
+};
+
+lazarus_result ModelManager::loadModel(ModelManager::Model &meshIn)
+{   
+    this->syncShader();
 
     LOG_DEBUG("Loading model data");
     ModelManager::ModelData &model = modelStore.at(meshIn.id);
@@ -1281,16 +1315,16 @@ void ModelManager::loadAnimation(ModelManager::MeshData &data)
     };
 };
 
+/*
+    Based on the current elapsed ms (time), determine
+    where abouts we are in the animation sequence. Use
+    this to look up and interpolate the relevant TRS 
+    keyframe values for the next draw of the animated
+    asset.
+*/
 glm::mat4 ModelManager::computeLocalJointTransform(ModelManager::MeshData::MotionPoint &motionPoint, uint32_t animationID)
 {
     AssetLoader::AssetData::JointMotion motionData = motionPoint.animationData[animationID];
-    /*
-        Based on the current elapsed ms (time), determine
-        where abouts we are in the animation sequence. Use
-        this to look up and interpolate the relevant TRS 
-        keyframe values for the next draw of the animated
-        asset.
-    */
     uint32_t prev = motionPoint.playbackPosition;
 
     uint32_t translateIdx = this->getKeyframeIndex(motionData.translation, motionPoint.playbackPosition, motionPoint.elapsedPlaytime, motionPoint.previousPlaytime);

--- a/src/lazarus_mesh.cpp
+++ b/src/lazarus_mesh.cpp
@@ -714,6 +714,10 @@ lazarus_result ModelManager::createCube(ModelManager::Model &out, ModelManager::
 
 };
 
+/**
+ * Generates the models main Vertex attribute object amongst other VBO's, packs them with vertex
+ * data and desribes to OpenGL how all of this should be interpretted on the GPU. 
+ */
 lazarus_result ModelManager::uploadVertexData()
 {	
     LOG_DEBUG("Allocating vertex array object");
@@ -1029,6 +1033,12 @@ lazarus_result ModelManager::clearMeshStorage()
     return this->checkErrors(__FILE__, __LINE__);
 };
 
+/**
+ * Checks for room in the stencil buffer. If room is found a stencil buffer ID is assigned to the 
+ * model and each of its composite meshes, as well as their GPU instances. This allows
+ * an item to be located on-screen while amongst others by doing a pixel lookup and comparing with 
+ * the stencil buffer.
+ */
 lazarus_result ModelManager::setSelectable(bool selectable)
 {
     try
@@ -1327,14 +1337,17 @@ glm::mat4 ModelManager::computeLocalJointTransform(ModelManager::MeshData::Motio
     AssetLoader::AssetData::JointMotion motionData = motionPoint.animationData[animationID];
     uint32_t prev = motionPoint.playbackPosition;
 
+    //  Locate keyframes    
     uint32_t translateIdx = this->getKeyframeIndex(motionData.translation, motionPoint.playbackPosition, motionPoint.elapsedPlaytime, motionPoint.previousPlaytime);
     uint32_t rotateIdx = this->getKeyframeIndex(motionData.rotation, motionPoint.playbackPosition, motionPoint.elapsedPlaytime, motionPoint.previousPlaytime);
     uint32_t scaleIdx = this->getKeyframeIndex(motionData.scale, motionPoint.playbackPosition, motionPoint.elapsedPlaytime, motionPoint.previousPlaytime);
 
+    //  Extract keyframe transform values
     glm::vec4 translateKey = this->getTransformLerp(motionData.translation, translateIdx, motionPoint.playbackPosition);
     glm::vec4 rotateKey = this->getTransformLerp(motionData.rotation, rotateIdx, motionPoint.playbackPosition);
     glm::vec4 scaleKey = this->getTransformLerp(motionData.scale, scaleIdx, motionPoint.playbackPosition);
 
+    //  construct a joint transform matrix using keyframe values
     glm::mat4 localTransform = (
         glm::translate(glm::mat4(1.0f), glm::vec3(translateKey)) *
         glm::mat4_cast(glm::quat(rotateKey.w, rotateKey.x, rotateKey.y, rotateKey.z)) *
@@ -1349,9 +1362,13 @@ glm::mat4 ModelManager::computeLocalJointTransform(ModelManager::MeshData::Motio
     return localTransform;
 };
 
+/**
+ * Uses the current elapsed time to locate the indices of the keyframe that should 
+ * next be iterated to and interpolated against the current frame.
+ */
 uint32_t ModelManager::getKeyframeIndex(AssetLoader::AssetData::JointMotion::TransformData motion, uint32_t &playbackPosition, uint32_t &elapsedMs, uint32_t &previousMs)
 {
-    /*
+    /**
         Determine how many ms have passed since this was
         last called.
 
@@ -1399,13 +1416,14 @@ uint32_t ModelManager::getKeyframeIndex(AssetLoader::AssetData::JointMotion::Tra
     return index;
 };
 
+/*
+    Calculate the linear interpolation between keyframe values. Note that 
+    cubicspline interpolation is not supported.
+*/
 glm::vec4 ModelManager::getTransformLerp(AssetLoader::AssetData::JointMotion::TransformData motion, uint32_t frameBegin, uint32_t playbackPosition)
 {
-    /*
-        Calculate keyframe interpolation. Note that cubicspline is
-        not supported.
-
-        TODO/FIXME:
+    /**
+        TODO:
         Handle static joints that may not have a JointMotion present at 
         all, I haven't seen this but it's a thing. In the cases identified so 
         far, they typically have exactly two keyframe indices with identical
@@ -1537,7 +1555,7 @@ lazarus_result ModelManager::pauseAnimation(ModelManager::Model &meshIn)
 
 lazarus_result ModelManager::playAnimation(ModelManager::Model &meshIn)
 {
-    /*
+    /**
         FIXME:
         This doesn't quite work as it should. There is 
         an observable "jump" during playback following
@@ -1679,6 +1697,10 @@ void ModelManager::setDiscardFragments(ModelManager::Model &meshIn, bool shouldD
     return;
 };
 
+/**
+ * Determines whether the model's meshes contain primitives that use image textures 
+ * or instead are composed by defined properties.
+ */
 lazarus_result ModelManager::setMaterials(AssetLoader::AssetData &assetData)
 {
     LOG_DEBUG("Loading material properties");
@@ -1732,6 +1754,9 @@ lazarus_result ModelManager::setMaterials(AssetLoader::AssetData &assetData)
     return lazarus_result::LAZARUS_OK;
 };
 
+/**
+ * Initialises `this->modelOut`'s default properties
+*/
 void ModelManager::setMeshProperties(AssetLoader::AssetData &assetData)
 {
     LOG_DEBUG("Loading base mesh properties");
@@ -1756,6 +1781,9 @@ void ModelManager::setMeshProperties(AssetLoader::AssetData &assetData)
    return;
 }
 
+/**
+ * Identifies and reports on issues with OpenGL
+*/
 lazarus_result ModelManager::checkErrors(const char *file, uint32_t line)
 {
     this->errorCode = glGetError();
@@ -1771,21 +1799,20 @@ lazarus_result ModelManager::checkErrors(const char *file, uint32_t line)
     return lazarus_result::LAZARUS_OK;
 };
 
+/**
+    Resets OpenGL's error state by flushing out all of the 
+    internal state flags containing the error value (which may 
+    be several). This is so that persistence of an errors 
+    life span is limitted to that function which caused it. 
+    By doing so, subsequent glGetError calls made from a function
+    other than that which actually caused the error will NOT 
+    throw. 
+    
+    Absolutely painful, see:
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetError.xhtml#:~:text=glGetError%20should%20always%20be%20called%20in%20a%20loop
+ */
 void ModelManager::clearErrors()
 {
-    /*
-        Reset OpenGL's error state by flushing out all of the 
-        internal state flags containing the error value (which may 
-        be several). This is so that persistence of an errors 
-        life span is limitted to that function which caused it. 
-        By doing so, subsequent glGetError calls made from a function
-        other than that which actually caused the error will NOT 
-        throw. 
-        
-        Absolutely painful, see:
-        https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetError.xhtml#:~:text=glGetError%20should%20always%20be%20called%20in%20a%20loop
-    */
-
     this->errorCode = glGetError();
 
     while(this->errorCode != GL_NO_ERROR)
@@ -1824,6 +1851,9 @@ void ModelManager::copyModel(ModelManager::Model &dest, ModelManager::Model src)
     return;
 };
 
+/**
+ * Generates a buffer used to handle a meshes GPU instance data
+*/
 void ModelManager::instantiateMesh(bool selectable)
 {   
     LOG_DEBUG("Loading mesh instance(s)");

--- a/src/lazarus_mesh.cpp
+++ b/src/lazarus_mesh.cpp
@@ -34,15 +34,6 @@ ModelManager::ModelManager(Shader &shader, TextureLoader::StorageType textureTyp
 
     shader.getActiveShader(this->activeShaderID);
     this->updateUniformLocations();
-    
-    /*
-        Bind samplers to texture units and load locations.
-        https://www.khronos.org/opengl/wiki/Sampler_(GLSL)#:~:text=The%20value%20you%20provide%20to%20a%20sampler%20uniform%20is%20the%20texture%20image%20unit%20to%20which%20you%20will%20bind%20the%20texture%20that%20the%20sampler%20will%20access
-    */
-
-    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureAtlas"), 1);
-    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureArray"), 2);
-    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureCube"), 3);
 
     this->maxTexWidth = 0;
     this->maxTexHeight = 0;
@@ -354,6 +345,14 @@ lazarus_result ModelManager::updateUniformLocations()
     this->meshVariantLocation           = glGetUniformLocation(this->activeShaderID, "samplerType");
     this->discardFragsLocation          = glGetUniformLocation(this->activeShaderID, "discardFrags");
     this->isAnimatedLocation            = glGetUniformLocation(this->activeShaderID, "isAnimated");
+
+    /*
+        Bind samplers to texture units and load locations.
+        https://www.khronos.org/opengl/wiki/Sampler_(GLSL)#:~:text=The%20value%20you%20provide%20to%20a%20sampler%20uniform%20is%20the%20texture%20image%20unit%20to%20which%20you%20will%20bind%20the%20texture%20that%20the%20sampler%20will%20access
+    */
+    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureAtlas"), 1);
+    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureArray"), 2);
+    glUniform1i(glGetUniformLocation(this->activeShaderID, "textureCube"), 3);
 
     return this->checkErrors(__FILE__, __LINE__);
 }
@@ -1102,9 +1101,9 @@ lazarus_result ModelManager::syncShader()
     uint32_t program = 0;
     /**
      * TODO:
-     * During creation, uploadTextures needs to be called for each known program - not just the active one.
-     * The implications of the current behaviour mean that _lazarusComputeColor() cannot be called from any shader 
-     * other than that which was active during creation for models whose meshes use textures.
+     * updateUniformLocations is expensive, the result should be cached on-create
+     * that way; all that needs to be done here is a simple lookup in memory 
+     * followed by glUniform* (i.e. remove glGetUniformLocation)
      */
     shader->getActiveShader(program);
     if(this->activeShaderID != program)
@@ -1112,7 +1111,7 @@ lazarus_result ModelManager::syncShader()
         this->activeShaderID = program;
         status = this->updateUniformLocations();
     };
-    
+
     return status;
 };
 

--- a/src/lazarus_mesh.cpp
+++ b/src/lazarus_mesh.cpp
@@ -443,10 +443,10 @@ lazarus_result ModelManager::createQuad(ModelManager::Model &out, ModelManager::
         (E.g. width 2.0f, height 2.0f becomes 
         width -1.0f, height +1.0f) 
     */
-    float xMin = -(options.width / 2.0f);
-    float xMax = options.width / 2.0f;
-    float yMax = options.height / 2.0f;
-    float yMin = -(options.height / 2.0f);
+    float xMin = -(options.width * 0.5f);
+    float xMax = options.width * 0.5f;
+    float yMax = options.height * 0.5f;
+    float yMin = -(options.height * 0.5f);
     /*
         If the UV params aren't their default values (0.0) then
         this mesh is being created for a glyph which needs to be 
@@ -554,7 +554,7 @@ lazarus_result ModelManager::createCube(ModelManager::Model &out, ModelManager::
     this->syncShader();
     
     LOG_DEBUG("Generating cube");
-    float vertexPosition = options.scale / 2.0f; 
+    float vertexPosition = options.scale * 0.5f; 
     
     AssetLoader::AssetData assetData = {};
     this->modelOut = {};
@@ -676,7 +676,7 @@ lazarus_result ModelManager::createCube(ModelManager::Model &out, ModelManager::
         Zero-out movement / animation buf
     */
     assetData.movements.clear();
-    assetData.movements.resize(assetData.attributes.size() / 2, glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
+    assetData.movements.resize(assetData.attributes.size() * 0.5f, glm::vec4(0.0f, 0.0f, 0.0f, 0.0f));
 
     this->meshData = {};
     this->meshData.texture.unitId = textureUnit;

--- a/src/lazarus_mesh.cpp
+++ b/src/lazarus_mesh.cpp
@@ -115,147 +115,156 @@ lazarus_result ModelManager::create3DAsset(ModelManager::Model &out, ModelManage
                 Flatten out this map and resolve indices 
                 corrections.
             */
-            std::map<uint32_t, AssetLoader::AssetData::JointData> rig = assetData.armature;
-
-            std::set<uint32_t> heirachy;
-            for(auto pair : rig)
+            if(assetData.armature.size() > LAZARUS_MAX_MOTIONPOINTS)
             {
-                MeshData::MotionPoint motionPoint = {};
-                AssetLoader::AssetData::JointData jointData = pair.second;
+                LOG_ERROR("Asset Error:", __FILE__, __LINE__);
 
-                motionPoint.id = jointData.id;
-                motionPoint.inverseBindMatrix = jointData.inverseBindMatrix;
-
-                /*
-                    Obtain the movement data for this joint for each 
-                    animation that can be enacted by the armature.
-                */
-                for(size_t j = 0; j < assetData.animations.size(); j++)
-                {
-                    AssetLoader::AssetData::JointMotion jointMotion = assetData.animations[j].at(jointData.id);
-                    motionPoint.animationData.push_back(jointMotion);
-                };
-
-                /*
-                    Compute the transformation matrix required
-                    for moving into the bind-pose. 
-                    
-                    Note: Blender exports its' quats with 'w' on 
-                    the wrong side.
-                */
-                motionPoint.localJointTransform = (
-                    glm::translate(glm::mat4(1.0f), jointData.translation) *
-                    glm::mat4_cast(glm::quat(jointData.rotation.w, jointData.rotation.x, jointData.rotation.y, jointData.rotation.z)) * 
-                    glm::scale(glm::mat4(1.0f), jointData.scale)
-                );
-                motionPoint.globalJointTransform = motionPoint.localJointTransform;
-                motionPoint.jointMatrix = glm::mat4(0.0f);
-                
-                /*
-                    Look up the children of the joints actual 
-                    IDs relative to the flattened armature.
-                */
-                for(size_t k = 0; k < jointData.children.size(); k++)
-                {
-                    uint32_t childID = jointData.children[k];
-                    uint32_t index = assetData.armature.at(childID).id;
-                    motionPoint.children.push_back(index);
-
-                    heirachy.insert(index);
-                };
-                
-                meshData.armature.push_back(motionPoint);
-            };
-            
-            /*
-                Ensure flattened armature is indexed in
-                the same order of appearance as the glb 
-                'skins' vector.
-            */
-            std::sort(
-                meshData.armature.begin(), 
-                meshData.armature.end(), 
-                [](MeshData::MotionPoint &jointA, MeshData::MotionPoint &jointB) {
-                    return jointA.id < jointB.id;
-                }
-            );
-            
-
-            /*
-                Determine the armature's root joint (The only node 
-                in the tree which is never referred to as a child of 
-                another node).
-
-                TODO:
-                This should be extended to be more inclusive of 
-                armatures with multiple roots (forests).
-            */
-            for(size_t j = 0; j < meshData.armature.size(); j++)
+                return lazarus_result::LAZARUS_LIMIT_REACHED;
+            }
+            else
             {
-                if(heirachy.insert(j).second)
-                {
-                    meshData.armatureRoot = j;
-                    break;
-                };
-            };
-
-            /*
-                Traverse joint structure from root and apply 
-                transforms forward to children as the tree is 
-                descended.
-
-                I.e. Breadth-first search begin.
-            */
-            MeshData::MotionPoint &rootJoint = meshData.armature[meshData.armatureRoot];
-            std::vector<uint32_t> children = rootJoint.children;
-            std::vector<uint32_t> parents;
-
-            parents.resize(rootJoint.children.size(), meshData.armatureRoot);
-            std::set<uint32_t> visited = {rootJoint.id};
-
-            rootJoint.parentID = -1;
-            rootJoint.posePosition = rootJoint.globalJointTransform;
-            rootJoint.jointMatrix = rootJoint.globalJointTransform * rootJoint.inverseBindMatrix;
-            
-            while(!std::empty(children))
-            {
-                std::vector<uint32_t> nextChildren;
-                std::vector<uint32_t> nextParents;
-
-                for(size_t k = 0; k < children.size(); k++)
-                {
-                    uint32_t childID = children[k];
-                    uint32_t parentID = parents[k];
-
-                    if(visited.insert(childID).second)
-                    {
-                        MeshData::MotionPoint &child = meshData.armature[childID];
-                        MeshData::MotionPoint &parent = meshData.armature[parentID];
-                        nextChildren.insert(
-                            nextChildren.end(), 
-                            child.children.begin(), 
-                            child.children.end()
-                        );
-                        nextParents.resize(nextParents.size() + child.children.size(), childID);
+                std::map<uint32_t, AssetLoader::AssetData::JointData> rig = assetData.armature;
     
-                        /*
-                            Compute the pose and set it as the joint 
-                            matrix value required for vertex skinning
-                            by editting the rig in-place.
-                        */
-                        glm::mat4 localTransform = child.globalJointTransform;
-                        child.parentID = parentID;
-                        child.globalJointTransform = parent.globalJointTransform * localTransform;
-                        child.posePosition = child.globalJointTransform;
-                        child.jointMatrix = child.globalJointTransform * child.inverseBindMatrix;
+                std::set<uint32_t> heirachy;
+                for(auto pair : rig)
+                {
+                    MeshData::MotionPoint motionPoint = {};
+                    AssetLoader::AssetData::JointData jointData = pair.second;
+    
+                    motionPoint.id = jointData.id;
+                    motionPoint.inverseBindMatrix = jointData.inverseBindMatrix;
+    
+                    /*
+                        Obtain the movement data for this joint for each 
+                        animation that can be enacted by the armature.
+                    */
+                    for(size_t j = 0; j < assetData.animations.size(); j++)
+                    {
+                        AssetLoader::AssetData::JointMotion jointMotion = assetData.animations[j].at(jointData.id);
+                        motionPoint.animationData.push_back(jointMotion);
+                    };
+    
+                    /*
+                        Compute the transformation matrix required
+                        for moving into the bind-pose. 
+                        
+                        Note: Blender exports its' quats with 'w' on 
+                        the wrong side.
+                    */
+                    motionPoint.localJointTransform = (
+                        glm::translate(glm::mat4(1.0f), jointData.translation) *
+                        glm::mat4_cast(glm::quat(jointData.rotation.w, jointData.rotation.x, jointData.rotation.y, jointData.rotation.z)) * 
+                        glm::scale(glm::mat4(1.0f), jointData.scale)
+                    );
+                    motionPoint.globalJointTransform = motionPoint.localJointTransform;
+                    motionPoint.jointMatrix = glm::mat4(0.0f);
+                    
+                    /*
+                        Look up the children of the joints actual 
+                        IDs relative to the flattened armature.
+                    */
+                    for(size_t k = 0; k < jointData.children.size(); k++)
+                    {
+                        uint32_t childID = jointData.children[k];
+                        uint32_t index = assetData.armature.at(childID).id;
+                        motionPoint.children.push_back(index);
+    
+                        heirachy.insert(index);
+                    };
+                    
+                    meshData.armature.push_back(motionPoint);
+                };
+                
+                /*
+                    Ensure flattened armature is indexed in
+                    the same order of appearance as the glb 
+                    'skins' vector.
+                */
+                std::sort(
+                    meshData.armature.begin(), 
+                    meshData.armature.end(), 
+                    [](MeshData::MotionPoint &jointA, MeshData::MotionPoint &jointB) {
+                        return jointA.id < jointB.id;
+                    }
+                );
+                
+    
+                /*
+                    Determine the armature's root joint (The only node 
+                    in the tree which is never referred to as a child of 
+                    another node).
+    
+                    TODO:
+                    This should be extended to be more inclusive of 
+                    armatures with multiple roots (forests).
+                */
+                for(size_t j = 0; j < meshData.armature.size(); j++)
+                {
+                    if(heirachy.insert(j).second)
+                    {
+                        meshData.armatureRoot = j;
+                        break;
                     };
                 };
-
-                children = nextChildren;
-                parents = nextParents;
+    
+                /*
+                    Traverse joint structure from root and apply 
+                    transforms forward to children as the tree is 
+                    descended.
+    
+                    I.e. Breadth-first search begin.
+                */
+                MeshData::MotionPoint &rootJoint = meshData.armature[meshData.armatureRoot];
+                std::vector<uint32_t> children = rootJoint.children;
+                std::vector<uint32_t> parents;
+    
+                parents.resize(rootJoint.children.size(), meshData.armatureRoot);
+                std::set<uint32_t> visited = {rootJoint.id};
+    
+                rootJoint.parentID = -1;
+                rootJoint.posePosition = rootJoint.globalJointTransform;
+                rootJoint.jointMatrix = rootJoint.globalJointTransform * rootJoint.inverseBindMatrix;
+                
+                while(!std::empty(children))
+                {
+                    std::vector<uint32_t> nextChildren;
+                    std::vector<uint32_t> nextParents;
+    
+                    for(size_t k = 0; k < children.size(); k++)
+                    {
+                        uint32_t childID = children[k];
+                        uint32_t parentID = parents[k];
+    
+                        if(visited.insert(childID).second)
+                        {
+                            MeshData::MotionPoint &child = meshData.armature[childID];
+                            MeshData::MotionPoint &parent = meshData.armature[parentID];
+                            nextChildren.insert(
+                                nextChildren.end(), 
+                                child.children.begin(), 
+                                child.children.end()
+                            );
+                            nextParents.resize(nextParents.size() + child.children.size(), childID);
+        
+                            /*
+                                Compute the pose and set it as the joint 
+                                matrix value required for vertex skinning
+                                by editting the rig in-place.
+                            */
+                            glm::mat4 localTransform = child.globalJointTransform;
+                            child.parentID = parentID;
+                            child.globalJointTransform = parent.globalJointTransform * localTransform;
+                            child.posePosition = child.globalJointTransform;
+                            child.jointMatrix = child.globalJointTransform * child.inverseBindMatrix;
+                        };
+                    };
+    
+                    children = nextChildren;
+                    parents = nextParents;
+                };
             };
-        };
-
+    
+        };   
         this->instantiateMesh(options.selectable);
         
         status = this->setMaterials(assetData);
@@ -271,8 +280,7 @@ lazarus_result ModelManager::create3DAsset(ModelManager::Model &out, ModelManage
         };
             
         this->modelData.push_back(this->meshData);
-    };
-    
+    }
     
     try
     {
@@ -327,7 +335,7 @@ lazarus_result ModelManager::uploadTextures()
             };
         };
     };
-
+    
     return status;
 };
 
@@ -1046,7 +1054,7 @@ lazarus_result ModelManager::setSelectable(bool selectable)
         if (selectable)
         {
             LOG_DEBUG("Determining a pickable ID for the asset");
-            if (numOccupants < UINT8_MAX)
+            if (numOccupants < LAZARUS_MAX_SELECTABLE_ENTITIES)
             {
                 /*
                     Items which can be picked from the stencil-
@@ -1068,6 +1076,7 @@ lazarus_result ModelManager::setSelectable(bool selectable)
             }
             else
             {
+                LOG_ERROR("Asset Error: ", __FILE__, __LINE__);
                 return lazarus_result::LAZARUS_LIMIT_REACHED;
             }
         }

--- a/src/lazarus_text_manager.cpp
+++ b/src/lazarus_text_manager.cpp
@@ -501,8 +501,8 @@ lazarus_result TextManager::loadText(TextManager::Text textIn)
             */
             status = transformer.translateModel(
                 quad, 
-                static_cast<float>((settings.location.x + (this->glyph.width / 2.0f)) + this->translationStride), 
-                static_cast<float>((settings.location.y + (this->rowHeight / 2.0f))), 
+                static_cast<float>((settings.location.x + (this->glyph.width * 0.5f)) + this->translationStride), 
+                static_cast<float>((settings.location.y + (this->rowHeight * 0.5f))), 
                 0.0f
             );
             if(status != lazarus_result::LAZARUS_OK)

--- a/src/lazarus_text_manager.cpp
+++ b/src/lazarus_text_manager.cpp
@@ -657,10 +657,17 @@ void TextManager::lookUpUVs(uint8_t keyCode, uint32_t fontId)
     /*
         Normalise the values of the pixel locations within
         the dimensions of the texture atlas.
+        
+        NOTE: 
+        1.0f is minused from uvR and 2.0f from uvU to stop an
+        issue with clipping parts of other letters from other
+        alphabets, an issue introduced at the same time as
+        multi-font support. This is could be better solved by
+        performing this offset in the actual atlas but OK for now.
     */
-    this->uvL = static_cast<float>(targetXL) / uvRangeX;
-    this->uvR = static_cast<float>(targetXR) / uvRangeX;
-    this->uvU = static_cast<float>(this->alphabetHeights[(fontId * 2) + 1]) / uvRangeY;
+    this->uvL = static_cast<float>(targetXL + 1.0f) / uvRangeX;
+    this->uvR = static_cast<float>(targetXR - 1.0f) / uvRangeX;
+    this->uvU = static_cast<float>((this->alphabetHeights[(fontId * 2) + 1]) - 2.0f) / uvRangeY;
     this->uvD = static_cast<float>(this->alphabetHeights[(fontId * 2)]) / uvRangeY;
 
     return;

--- a/src/lazarus_texture_loader.cpp
+++ b/src/lazarus_texture_loader.cpp
@@ -332,13 +332,13 @@ void TextureLoader::calculateMipLevels(uint32_t &mipCount, uint32_t width, uint3
 
 		if(mipWidth != 1)
 		{
-			uint32_t xResult = static_cast<uint32_t>(floor(mipWidth / 2));
+			uint32_t xResult = static_cast<uint32_t>(floor(mipWidth * 0.5f));
 			mipWidth = xResult;
 		}
 
 		if (mipHeight != 1)
 		{
-			uint32_t yResult = static_cast<uint32_t>(floor(mipHeight / 2));
+			uint32_t yResult = static_cast<uint32_t>(floor(mipHeight * 0.5f));
 			mipHeight = yResult;
 		}
 

--- a/src/lazarus_window_manager.cpp
+++ b/src/lazarus_window_manager.cpp
@@ -119,22 +119,12 @@ lazarus_result EventManager::eventsInit()
 	if(win != NULL)
 	{
 		glfwSetKeyCallback(win, [](GLFWwindow *win, int key, int scancode, int action, int mods){ 
-			// int32_t code = 0;
-			// int32_t scan = 0;
-			
-			// if(action != GLFW_RELEASE)
-			// {
-			// 	code = key;
-			// 	scan = scancode;
-			// };
-
 			EventType type = action != GLFW_RELEASE
 			? EventType::KEY_DOWN
 			: EventType::KEY_UP;
 			
 			WindowManager *window = (WindowManager *) glfwGetWindowUserPointer(win);
 			window->dispatchEvent(type, key, scancode);
-			// window->dispatchEvent(EventType::KEY_PRESS, code, scan);
 
 			return;
 		});
@@ -197,8 +187,13 @@ lazarus_result EventManager::monitorEvents()
 
 		Keys which are held down between press and
 		release and seeded at the head of the queue.
+
+		Copy snapshot of the private queue (that could be updated
+		by a callback mid-frame) to the public queue to be
+		used as a single source of truth for the user.
 	*/
-	this->eventQueue.clear();
+	this->eventQueue = this->events;
+	this->events.clear();
 	/**
 	 * TODO:
 	 * Add the scancode in here or do away with it altogether.
@@ -209,7 +204,7 @@ lazarus_result EventManager::monitorEvents()
 		e.type = EventType::KEY_HOLD;
 		e.key = keyCode;
 		
-		eventQueue.push_back(e);
+		events.push_back(e);
 	}
 
 	/*
@@ -422,7 +417,7 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 				this->latestKeyState = aValue;
 				this->latestScanState = bValue;
 
-				this->eventQueue.push_back(event);
+				this->events.push_back(event);
 			}
 			break;
 		}
@@ -437,7 +432,7 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 			this->latestKeyState = 0;
 			this->latestScanState = 0;
 
-			this->eventQueue.push_back(event);
+			this->events.push_back(event);
 			break;
 		}
 
@@ -447,7 +442,7 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 				event.click = aValue;
 				this->latestClickState = aValue;
 
-				this->eventQueue.push_back(event);
+				this->events.push_back(event);
 			};
 			break;
 
@@ -461,7 +456,7 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 				this->latestMouseXState = aValue;
 				this->latestMouseYState = bValue;
 
-				this->eventQueue.push_back(event);
+				this->events.push_back(event);
 			};
 			break;
 
@@ -471,7 +466,7 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 				event.scroll = aValue;
 				this->latestScrollState = aValue;
 
-				this->eventQueue.push_back(event);
+				this->events.push_back(event);
 			};
 			break;
 		

--- a/src/lazarus_window_manager.cpp
+++ b/src/lazarus_window_manager.cpp
@@ -119,17 +119,22 @@ lazarus_result EventManager::eventsInit()
 	if(win != NULL)
 	{
 		glfwSetKeyCallback(win, [](GLFWwindow *win, int key, int scancode, int action, int mods){ 
-			int32_t code = 0;
-			int32_t scan = 0;
+			// int32_t code = 0;
+			// int32_t scan = 0;
 			
-			if(action != GLFW_RELEASE)
-			{
-				code = key;
-				scan = scancode;
-			};
+			// if(action != GLFW_RELEASE)
+			// {
+			// 	code = key;
+			// 	scan = scancode;
+			// };
+
+			EventType type = action != GLFW_RELEASE
+			? EventType::KEY_DOWN
+			: EventType::KEY_UP;
 			
 			WindowManager *window = (WindowManager *) glfwGetWindowUserPointer(win);
-			window->dispatchEvent(EventType::KEY_PRESS, code, scan);
+			window->dispatchEvent(type, key, scancode);
+			// window->dispatchEvent(EventType::KEY_PRESS, code, scan);
 
 			return;
 		});
@@ -189,8 +194,24 @@ lazarus_result EventManager::monitorEvents()
 		at the time of the previous call to poll and 
 		replace them with any events processed via
 		callbacks inbetween.
+
+		Keys which are held down between press and
+		release and seeded at the head of the queue.
 	*/
 	this->eventQueue.clear();
+	/**
+	 * TODO:
+	 * Add the scancode in here or do away with it altogether.
+	 */
+	for(int32_t keyCode : heldKeys)
+	{
+		Event e = {};
+		e.type = EventType::KEY_HOLD;
+		e.key = keyCode;
+		
+		eventQueue.push_back(e);
+	}
+
 	/*
 		The glfw scroll state when monitored can only be on or
 		off - there is no scroll "neutral" state, so one is 
@@ -389,8 +410,11 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 	*/
 	switch (event.type)
 	{
-		case EventType::KEY_PRESS:
-			if(this->latestKeyState != aValue)
+		case EventType::KEY_DOWN:
+		{
+			/* Check that the queue contains no instances of this key already */
+			auto it = heldKeys.insert(aValue);
+			if(it.second)
 			{
 				event.key = aValue;
 				event.keyVariant = bValue;
@@ -399,8 +423,23 @@ void EventManager::dispatchEvent(EventManager::EventType variant, int32_t aValue
 				this->latestScanState = bValue;
 
 				this->eventQueue.push_back(event);
-			};
+			}
 			break;
+		}
+
+		case EventType::KEY_UP:
+		{
+			heldKeys.erase(aValue);
+
+			event.key = aValue;
+			event.keyVariant = bValue;
+
+			this->latestKeyState = 0;
+			this->latestScanState = 0;
+
+			this->eventQueue.push_back(event);
+			break;
+		}
 
 		case EventType::CLICK:
 			if(this->latestClickState != aValue)

--- a/src/lazarus_window_manager.cpp
+++ b/src/lazarus_window_manager.cpp
@@ -880,8 +880,8 @@ lazarus_result WindowManager::checkErrors(const char *file, int line)
 
 lazarus_result WindowManager::centerWindow()
 {
-	int32_t windowLocationX = floor((videoMode->width - this->frame.width) / 2);
-	int32_t windowLocationY = floor((videoMode->height - this->frame.height) / 2);
+	int32_t windowLocationX = floor((videoMode->width - this->frame.width) * 0.5f);
+	int32_t windowLocationY = floor((videoMode->height - this->frame.height) * 0.5f);
     glfwSetWindowPos(this->window, windowLocationX, windowLocationY);
 
 	return this->checkErrors(__FILE__, __LINE__);


### PR DESCRIPTION
* Ensures that the constituents of a `Shader` manager have their uniform variables correctly synchronized to the active shader program on calls to load / create functions
* Cleaned up documentation
* Updates the numeric limits of shader uniforms and the location of their definitions
* Replaces division operations with their decimal point multiplication counterparts
* Introduces a `KEY_HOLD` state and various improvements to event queue handling
* Removes artifacts from rendering of text glyphs